### PR TITLE
Change command 'everything'

### DIFF
--- a/training.py
+++ b/training.py
@@ -218,7 +218,7 @@ class Training(Skill):
     @command("everything")
     def everything(self, message, args):
 
-        everything = "\n".join([str(r+1) + ". " + str(rule) for r, rule in enumerate(self.rules)])
+        everything = "\n".join([str(r+1) + ". " + str(rule).replace("://","[:]//") for r, rule in enumerate(self.rules)])
         message.reply("All trained rules:\n\n" + everything)
 
 


### PR DESCRIPTION
Replaces https:// with https[:]// in command 'everything' before Bot posts the trained rules, because else HipChat is spamming with HTML cards.
